### PR TITLE
[PR] Use `get_current_network_id()` for current network

### DIFF
--- a/includes/class-wsu-search.php
+++ b/includes/class-wsu-search.php
@@ -136,8 +136,8 @@ class WSUWP_Search {
 			$data['site_url'] .= $home_url['path'];
 		}
 
-		if ( function_exists( 'wsuwp_get_current_network' ) ) {
-			$data['network_id'] = intval( wsuwp_get_current_network()->id );
+		if ( is_multisite() ) {
+			$data['network_id'] = get_current_network_id();
 		}
 
 		// Map each registered public taxonomy to the Elasticsearch document.


### PR DESCRIPTION
This replaces the custom function we were using.

See https://github.com/washingtonstateuniversity/WSUWP-Platform/issues/350